### PR TITLE
Allow depending on robot 4 for libraries using assertionengine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ include = ["assertionengine/py.typed"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-robotframework = "^3.2.2" || "^4.0.0"
+robotframework = "^3.2.2 || ^4.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ include = ["assertionengine/py.typed"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-robotframework = "^3.2.2"
+robotframework = "^3.2.2" || "^4.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.1"


### PR DESCRIPTION
As far as I understand assertion engine should work just fine on robot 4.0, and the unit tests pass. This makes opens up the requirement on pyproject.toml to enable projects (like Browser lib) to support both 3.2 and 4.0 with assertionengine.