### PR TITLE
Make _apply_to_expected return value instead of True (#42)

### DIFF
--- a/assertionengine/formatter.py
+++ b/assertionengine/formatter.py
@@ -12,8 +12,8 @@ def _normalize_spaces(value: str) -> str:
     return re.sub(r"\s+", " ", value)
 
 
-def _apply_to_expected(value: Any) -> bool:
-    return True
+def _apply_to_expected(value: Any) -> str:
+    return value
 
 
 FormatRules = {

--- a/atest/asserion_equal.robot
+++ b/atest/asserion_equal.robot
@@ -13,6 +13,17 @@ Set Assertion Formatters
         Length Should Be    ${formatters}[${formatter}]    2
     END
 
+Test With Assertion Formatter Apply To Expected
+    Set Assertion Formatters
+    ...    {"Is Equal": ["normalize spaces", "apply to expected"]}
+    Is Equal    A${SPACE*2}B    equal    A${SPACE*4}B
+
+Test Fail With Assertion Formatter Apply To Expected
+    [Documentation]    FAIL Prefix message 'A B' (str) should be 'A C' (str)
+    Set Assertion Formatters
+    ...    {"Is Equal": ["normalize spaces", "apply to expected"]}
+    Is Equal    A${SPACE*2}B    equal    A${SPACE*4}C
+
 Setting Assertion Formatters For Not Existing Keyword Should Fail
     [Documentation]    FAIL Could not find keyword from library.
     Set Assertion Formatters    {"Not Here": ["strip", "apply to expected"]}


### PR DESCRIPTION
Fixes #42 

I saw that ``True`` from ``_apply_to_expected`` was actually not needed, since the for loop in ``apply_to_expected`` only checks for presence of "_apply_to_expected`` formatter:

```
for formatter in formatters:
        if formatter.__name__ == "_apply_to_expected":
            return apply_formatters(expected, formatters)
```

So the minimalistic approach would be to only have ``_apply_to_expected`` return the value, i.e. do nothing.