### PR TITLE
Topic/list assertion always lists

### DIFF
--- a/assertionengine/assertion_engine.py
+++ b/assertionengine/assertion_engine.py
@@ -316,6 +316,8 @@ def list_verify_assertion(
     message="",
     custom_message="",
 ):
+    if operator is None:
+        return value
     if operator:
         if operator not in SequenceOperators:
             raise AttributeError(
@@ -328,9 +330,26 @@ def list_verify_assertion(
         ]:
             expected.sort()
             value.sort()
-    return verify_assertion(
-        map_list(value), operator, map_list(expected), message, custom_message
-    )
+        elif operator == AssertionOperator["contains"]:
+            if not BuiltIn().evaluate(
+                "all(item in value for item in expected)",
+                namespace={"value": value, "expected": expected},
+            ):
+                raise_error(
+                    custom_message,
+                    expected,
+                    " " if message else "",
+                    message,
+                    "should contain",
+                    value,
+                )
+            return value
+        elif operator in [
+            AssertionOperator["then"],
+            AssertionOperator["validate"],
+        ]:
+            expected = expected[0]
+    return verify_assertion(value, operator, expected, message, custom_message)
 
 
 def dict_verify_assertion(

--- a/atest/assertion_equal.robot
+++ b/atest/assertion_equal.robot
@@ -25,21 +25,21 @@ Test Fail With Assertion Formatter Apply To Expected
     TRY
         Is Equal    A${SPACE*2}B    equal    A${SPACE*4}C
     EXCEPT    Prefix message 'A B' (str) should be 'A C' (str)
-        Pass Execution    Error Message correct
+        Log    Error Message correct
     END
 
 Setting Assertion Formatters For Not Existing Keyword Should Fail
     TRY
         Set Assertion Formatters    {"Not Here": ["strip", "apply to expected"]}
     EXCEPT    Could not find keyword from library.
-        Pass Execution    Error Message Correct
+        Log    Error Message Correct
     END
 
 Setting Assertion Formatters For Not Existing Formatter Should Fail
     TRY
         Set Assertion Formatters    {"Is Equal": ["strip", "not here"]}
     EXCEPT    KeyError: 'not here'
-        Pass Execution    Error Message Correct
+        Log    Error Message Correct
     END
 
 Values Are Equal
@@ -61,14 +61,14 @@ Formatter Fails When Value Is Not Corrent Type
     TRY
         Is Equal As Number    ${SPACE}1${SPACE}    ==    ${1}
     EXCEPT    AttributeError: 'int' object has no attribute 'strip'
-        Pass Execution    Error Message Correct
+        Log    Error Message Correct
     END
 
 Values Are Equal Fails
     TRY
         Is Equal    1    ==    2
     EXCEPT    Prefix message '1' (str) should be '2' (str)
-        Pass Execution    Error Message Correct
+        Log    Error Message Correct
     END
 
 Values Are Equal Fails With Formatter
@@ -76,7 +76,7 @@ Values Are Equal Fails With Formatter
     TRY
         Is Equal    ${SPACE}1${SPACE}1    ==    ${SPACE}1${SPACE}2
     EXCEPT    Prefix message '1 1' (str) should be ' 1 2' (str)
-        Pass Execution    Error Message Correct
+        Log    Error Message Correct
     END
 
 Values Are Equal Fails When No assertion_operator

--- a/atest/assertion_equal.robot
+++ b/atest/assertion_equal.robot
@@ -20,18 +20,27 @@ Test With Assertion Formatter Apply To Expected
     Is Equal    A${SPACE*2}B    equal    A${SPACE*4}B
 
 Test Fail With Assertion Formatter Apply To Expected
-    [Documentation]    FAIL Prefix message 'A B' (str) should be 'A C' (str)
     Set Assertion Formatters
     ...    {"Is Equal": ["normalize spaces", "apply to expected"]}
-    Is Equal    A${SPACE*2}B    equal    A${SPACE*4}C
+    TRY
+        Is Equal    A${SPACE*2}B    equal    A${SPACE*4}C
+    EXCEPT    Prefix message 'A B' (str) should be 'A C' (str)
+        Pass Execution    Error Message correct
+    END
 
 Setting Assertion Formatters For Not Existing Keyword Should Fail
-    [Documentation]    FAIL Could not find keyword from library.
-    Set Assertion Formatters    {"Not Here": ["strip", "apply to expected"]}
+    TRY
+        Set Assertion Formatters    {"Not Here": ["strip", "apply to expected"]}
+    EXCEPT    Could not find keyword from library.
+        Pass Execution    Error Message Correct
+    END
 
 Setting Assertion Formatters For Not Existing Formatter Should Fail
-    [Documentation]    FAIL KeyError: 'not here'
-    Set Assertion Formatters    {"Is Equal": ["strip", "not here"]}
+    TRY
+        Set Assertion Formatters    {"Is Equal": ["strip", "not here"]}
+    EXCEPT    KeyError: 'not here'
+        Pass Execution    Error Message Correct
+    END
 
 Values Are Equal
     Is Equal    1    ==    1
@@ -48,18 +57,27 @@ Values Are Equal With Formatter For Expected
     ...    ${SPACE * 2}1${SPACE}1${SPACE}1${SPACE * 2}
 
 Formatter Fails When Value Is Not Corrent Type
-    [Documentation]    FAIL AttributeError: 'int' object has no attribute 'strip'
     Set Assertion Formatters    {"Is Equal As Number": ["strip", "normalize spaces"]}
-    Is Equal As Number    ${SPACE}1${SPACE}    ==    ${1}
+    TRY
+        Is Equal As Number    ${SPACE}1${SPACE}    ==    ${1}
+    EXCEPT    AttributeError: 'int' object has no attribute 'strip'
+        Pass Execution    Error Message Correct
+    END
 
 Values Are Equal Fails
-    [Documentation]    FAIL Prefix message '1' (str) should be '2' (str)
-    Is Equal    1    ==    2
+    TRY
+        Is Equal    1    ==    2
+    EXCEPT    Prefix message '1' (str) should be '2' (str)
+        Pass Execution    Error Message Correct
+    END
 
 Values Are Equal Fails With Formatter
-    [Documentation]    FAIL Prefix message '1 1' (str) should be ' 1 2' (str)
     Set Assertion Formatters    {"Is Equal": ["strip", "normalize spaces"]}
-    Is Equal    ${SPACE}1${SPACE}1    ==    ${SPACE}1${SPACE}2
+    TRY
+        Is Equal    ${SPACE}1${SPACE}1    ==    ${SPACE}1${SPACE}2
+    EXCEPT    Prefix message '1 1' (str) should be ' 1 2' (str)
+        Pass Execution    Error Message Correct
+    END
 
 Values Are Equal Fails When No assertion_operator
     Run Keyword And Expect Error


### PR DESCRIPTION
This is related to the issue [#2513](https://github.com/MarketSquare/robotframework-browser/issues/2513)

list_verify_assertion does now return a list always. `contains` operator uses all() with two lists now.