### PR TITLE
Documentation: added hint for Python inline flags

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Currently supported assertion operators are:
 +----------+---------------------------+------------------------------------------------------------------------------------+----------------------------------+
 | $=       | should end with, ends     | Checks if returned value ends with expected value.                                 | re.search(f"{expected}$", value) |
 +----------+---------------------------+------------------------------------------------------------------------------------+----------------------------------+
-| matches  |                           | Checks if given RegEx matches minimum once in returned value.                      | re.search(expected, value)       |
+| matches  |                           | Checks if given RegEx matches minimum once in returned value (supports Python [Regex inline flags](https://docs.python.org/3/library/re.html)). | re.search(expected, value)       |
 +----------+---------------------------+------------------------------------------------------------------------------------+----------------------------------+
 | validate |                           | Checks if given Python expression evaluates to True.                               |                                  |
 +----------+---------------------------+------------------------------------------------------------------------------------+----------------------------------+


### PR DESCRIPTION
With this PR I want to contribute a small improvement to the documentation: 
the `matches` operator lacks documentation about case insensitive matching. 
I tried and found out that it works to include the python inline flag into the expression. 